### PR TITLE
Update README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -20,6 +20,11 @@ curl https://sh.rustup.rs -sSf | sh
 
 👀 Take a look in `~/.cargo/bin`. `rustc`, `cargo` and `rustup`, should have just been installed there, along with the rest of the Rust toolchain.
 
+🦀 Run the following command on the terminal
+```bash
+rustup component add rls
+```
+
 ## IDE
 
 Setup an IDE of your choice. We strongly recommend the link:https://intellij-rust.github.io[Rust plugin] for Intellij as that's what we'll be coding along with but recognize it's not to everyone's tastes. If you're still determined to use something else, there is a list link:https://github.com/rust-unofficial/awesome-rust#ides[here] which has the usual suspects on it.  


### PR DESCRIPTION
added extra command needed to make Eclipse Corrosion meet its dependencies, otherwise you get a message around missing configuration opening the toml files.